### PR TITLE
Add BrickColor

### DIFF
--- a/docs/pages/syntax.mdx
+++ b/docs/pages/syntax.mdx
@@ -59,25 +59,26 @@ This is particularly useful if you're using Blink inside of a package, and don't
 You can define a primitive using the `type` keyword  
 Blink supports the following primitives:  
 
-|Name    |Size (Bytes)|Supports ranges  |Minimum        |Maximum      |Components| 
-|--------|------------|-----------------|---------------|-------------|----------|
-|u8      |1 Byte      |Yes              |0              |255          |No        |
-|u16     |2 Bytes     |Yes              |0              |65,535       |No        |
-|u32     |4 Bytes     |Yes              |0              |4,294,967,295|No        |
-|i8      |1 Byte      |Yes              |-128           |127          |No        |
-|i16     |2 Bytes     |Yes              |-32,768        |32,767       |No        |
-|i32     |4 Bytes     |Yes              |-2,147,483,648 |2,147,483,647|No        |
-|f16     |2 Bytes     |Yes              |-65504         |65504        |No        |
-|f32     |4 Bytes     |Yes              |−16777216      |16777216     |No        |
-|f64     |8 Bytes     |Yes              |-2^53          |2^53         |No        |
-|vector  |12 Bytes    |Yes (Magnitude)  |N/A            |N/A          |Yes (1)   |
-|buffer  |N/A         |Yes (buffer.len) |N/A            |65,535 Bytes |No        |
-|string  |N/A         |Yes (string.len) |N/A            |65,535 Bytes |No        |
-|boolean |1 Byte      |No               |N/A            |N/A          |No        |
-|CFrame  |24 Bytes    |No               |N/A            |N/A          |Yes (2)   |
-|Color3  |12 Bytes    |No               |N/A            |N/A          |No        |
-|Instance|4 Bytes     |No               |N/A            |N/A          |No        |
-|unknown |N/A         |No               |N/A            |N/A          |No        |
+|Name       |Size (Bytes)|Supports ranges  |Minimum        |Maximum      |Components| 
+|-----------|------------|-----------------|---------------|-------------|----------|
+|u8         |1 Byte      |Yes              |0              |255          |No        |
+|u16        |2 Bytes     |Yes              |0              |65,535       |No        |
+|u32        |4 Bytes     |Yes              |0              |4,294,967,295|No        |
+|i8         |1 Byte      |Yes              |-128           |127          |No        |
+|i16        |2 Bytes     |Yes              |-32,768        |32,767       |No        |
+|i32        |4 Bytes     |Yes              |-2,147,483,648 |2,147,483,647|No        |
+|f16        |2 Bytes     |Yes              |-65504         |65504        |No        |
+|f32        |4 Bytes     |Yes              |−16777216      |16777216     |No        |
+|f64        |8 Bytes     |Yes              |-2^53          |2^53         |No        |
+|vector     |12 Bytes    |Yes (Magnitude)  |N/A            |N/A          |Yes (1)   |
+|buffer     |N/A         |Yes (buffer.len) |N/A            |65,535 Bytes |No        |
+|string     |N/A         |Yes (string.len) |N/A            |65,535 Bytes |No        |
+|boolean    |1 Byte      |No               |N/A            |N/A          |No        |
+|CFrame     |24 Bytes    |No               |N/A            |N/A          |Yes (2)   |
+|BrickColor |2 Bytes     |No               |N/A            |N/A          |No        |
+|Color3     |12 Bytes    |No               |N/A            |N/A          |No        |
+|Instance   |4 Bytes     |No               |N/A            |N/A          |No        |
+|unknown    |N/A         |No               |N/A            |N/A          |No        |
 
 ## Attributes
 A type can be marked optional by appending `?` at the end.

--- a/src/Generator/Prefabs.luau
+++ b/src/Generator/Prefabs.luau
@@ -440,6 +440,25 @@ do
 	}
 end
 
+--> BrickColor
+do
+	Types.BrickColor = {
+		Read = function(Variable: string, Block: Block)
+			local Number = Block:Read(SHORT)
+			Block:Line(`{Block:Declare(Variable)} = BrickColor.new(buffer.readu16({RECIEVE_BUFFER}, {Number}))`)
+		end,
+		Write = function(Value: string, Block: Block)
+			Block:Line(`local BrickColor = {Value}`)
+			Types.u16.Write("BrickColor.Number", Block)
+		end
+	}
+	
+	Primitives.BrickColor = {
+		Type = "BrickColor",
+		Generate = GeneratePrimitivePrefab("BrickColor", Types.BrickColor)
+	}
+end
+
 --> Instance
 do
 	Types.Instance = {

--- a/src/Generator/init.luau
+++ b/src/Generator/init.luau
@@ -59,6 +59,7 @@ local DEBUG_GLOBALS = {
 	"local task = require(\"@lune/task\")\n",
 	"local game = _G.%s.game\n",
 	"local Color3 = _G.%s.Color3\n",
+	"local BrickColor = _G.%s.BrickColor\n",
 }
 
 local IGNORED_TYPES_IN_SHARED = {

--- a/src/Settings.luau
+++ b/src/Settings.luau
@@ -168,6 +168,12 @@ local Primitives: {[string]: Primitive} = {
         AllowsOptional = true,
         AllowedComponents = 0
     },
+    BrickColor = {
+        Component = false,
+        AllowsRange = false,
+        AllowsOptional = true,
+        AllowedComponents = 0
+    },
     unknown = {
         Component = false,
         AllowsRange = false,

--- a/test/Shared.luau
+++ b/test/Shared.luau
@@ -87,6 +87,17 @@ local function GetEnvironment()
         return Color3.new(R / 255, G / 255, B / 255)
     end
 
+    local function BrickColor__eq(a: BrickColor, b: BrickColor): boolean
+        return a.Number == b.Number
+    end
+
+    local BrickColor = {}
+    function BrickColor.new(number: number): BrickColor
+        local Object = {Number = number, __typeof = "BrickColor"}
+        setmetatable(Object, {__eq = BrickColor__eq})
+        return table.freeze(Object)
+    end
+
     return {
         game = {
             GetService = function(self, Service: string)
@@ -97,7 +108,8 @@ local function GetEnvironment()
 
         Color3 = Color3,
         Services = Services,
-        Instances = Instances
+        Instances = Instances,
+        BrickColor = BrickColor,
     }
 end
 

--- a/test/Sources/Test.blink
+++ b/test/Sources/Test.blink
@@ -23,6 +23,7 @@ type D = Color3
 export type Byte = u8
 
 export type Color = Color3
+export type BrickkColor = BrickColor
 
 export type ExactRange = f32(0)
 export type DecimalRange = f32(-5.5..10.5)

--- a/test/Test.luau
+++ b/test/Test.luau
@@ -58,11 +58,13 @@ local ServerEnvironment = require("Server")
 _G.client = {
     game = ClientEnvironment.game,
     Color3 = ClientEnvironment.Color3,
+    BrickColor = ClientEnvironment.BrickColor,
 }
 
 _G.server = {
     game = ServerEnvironment.game,
-    Color3 = ClientEnvironment.Color3,
+    Color3 = ServerEnvironment.Color3,
+    BrickColor = ServerEnvironment.BrickColor,
 }
 
 local Client = require("../Network/Client")
@@ -716,6 +718,14 @@ RunClosure("Color3", function()
     assert(Color.R == Deserialized.R, `Expected {Color.R}, got {Deserialized.R}`)
     assert(Color.G == Deserialized.G, `Expected {Color.G}, got {Deserialized.G}`)
     assert(Color.B == Deserialized.B, `Expected {Color.B}, got {Deserialized.B}`)
+end)
+
+RunClosure("BrickColor", function()
+    local BrickColor = BaseEnvironment.BrickColor.new(373)
+    local Serialized = Server.BrickkColor.Write(BrickColor)
+    local Deserialized = Server.BrickkColor.Read(Serialized)
+
+    assert(BrickColor == Deserialized, `Expected BrickColor number to be {BrickColor.Number}, got {Deserialized.Number}`)
 end)
 
 RunClosure("Nested Map", function()


### PR DESCRIPTION
Adds BrickColor as a primitive to blink, BrickColors can be replicated smaller than Color3s as the amount of possible BrickColors is in u16 range.