### PR TITLE
Fix variable shadowing in non-default unique blocks

### DIFF
--- a/src/Generator/Blocks.luau
+++ b/src/Generator/Blocks.luau
@@ -33,6 +33,7 @@ export type Block = typeof(setmetatable({} :: {
     Content: {string},
     Operation: Operation,
     Variables: {[string]: boolean},
+    OperationOffset: number,
 }, Block))
 
 function Block.new<Parent>(Parent: Block?, Unique: string?): Block
@@ -49,7 +50,8 @@ function Block.new<Parent>(Parent: Block?, Unique: string?): Block
             Bytes = 0,
             Counts = 0
         },
-        Variables = {}
+        Variables = {},
+        OperationOffset = 0,
     }, Block)
 end
 
@@ -80,9 +82,11 @@ function Block._operation(self: Block, Method: Method, Bytes: number): string
 
     if self.Unique ~= DEFAULT_UNIQUE then
         self:Comment(`{Method} {Bytes}`)
-        self:Line(`local OPERATION_OFFSET = {self.Unique}`)
+        local OperationOffset = `OPERATION_OFFSET_{self.OperationOffset}`
+        self.OperationOffset += 1
+        self:Line(`local {OperationOffset} = {self.Unique}`)
         self:Line(`{self.Unique} += {Bytes}`)
-        return "OPERATION_OFFSET"
+        return OperationOffset
     end
 
     return `{self.Unique} + {Offset}` 

--- a/test/Sources/Test.blink
+++ b/test/Sources/Test.blink
@@ -24,6 +24,7 @@ type D = Color3
 export type Byte = u8
 
 export type Color = Color3
+export type ColorArray = Color3[]
 export type DateSeconds = DateTime
 export type DateMilliseconds = DateTimeMillis
 export type BrickkColor = BrickColor

--- a/test/Test.luau
+++ b/test/Test.luau
@@ -728,6 +728,29 @@ RunClosure("Color3", function()
     assert(Color.B == Deserialized.B, `Expected {Color.B}, got {Deserialized.B}`)
 end)
 
+RunClosure("Color3 Array", function()
+    local Array = {}
+    for _ = 1, 32 do
+        table.insert(Array, BaseEnvironment.Color3.fromRGB(
+            math.random(0, 255),
+            math.random(0, 255),
+            math.random(0, 255)
+        ))
+    end
+
+    local Serialized = Server.ColorArray.Write(Array)
+    local Deserialized = Server.ColorArray.Read(Serialized)
+
+    assert(#Array == #Deserialized, `Expected {#Array} elements`)
+
+    for Index, Got in Deserialized do
+        local Expected = Array[Index]
+        assert(Expected.R == Got.R, `Expected {Expected.R}, got {Got.R}`)
+        assert(Expected.G == Got.G, `Expected {Expected.G}, got {Got.G}`)
+        assert(Expected.B == Got.B, `Expected {Expected.B}, got {Got.B}`)
+    end
+end)
+
 RunClosure("DateTime", function()
     local DateTime = BaseEnvironment.DateTime.fromUnixTimestamp(math.random(1, 2^30))
     local Serialized = Server.DateSeconds.Write(DateTime)


### PR DESCRIPTION
Fixes shadowing in non-default unique blocks (arrays) which caused issues with e.g. Color3 deserialization. Previously, the following code would be generated:
```luau
-- Read 1
local OPERATION_OFFSET = ARRAY_START_2
ARRAY_START_2 += 1
-- Read 1
local OPERATION_OFFSET = ARRAY_START_2
ARRAY_START_2 += 1
-- Read 1
local OPERATION_OFFSET = ARRAY_START_2
ARRAY_START_2 += 1
local Item_2 = Color3.fromRGB(buffer.readu8(RecieveBuffer, OPERATION_OFFSET), buffer.readu8(RecieveBuffer, OPERATION_OFFSET), buffer.readu8(RecieveBuffer, OPERATION_OFFSET))
```
which caused only the R value to be read.