### PR TITLE
fix(typescript): optional key typed as `key: type | undefined` instead of `key?: type`

### DIFF
--- a/src/Generator/Typescript.luau
+++ b/src/Generator/Typescript.luau
@@ -95,7 +95,8 @@ local function GetTypescriptType(State: State, Declaration: Type): (string, stri
 		for _, Field in Value.Values do
 			local Name = Field.Name
 			local FieldType = GetTypescriptType(State, Field)
-			table.insert(Fields, `{FormatKey(Name)}: {FieldType}`)
+			local Optional = Field.Type == "Optional" and "?" or ""
+			table.insert(Fields, `{FormatKey(Name)}{Optional}: {FieldType}`)
 		end
 
 		Type = `\{ {table.concat(Fields, ", ")}\ }`


### PR DESCRIPTION
This is a very simple and unclean fix since I wasn't able to understand the recursion that well but it works.