### PR TITLE
Switch `if (cond) then error() end` to use assertions

### DIFF
--- a/compiler/lir/build/builders/library/init.luau
+++ b/compiler/lir/build/builders/library/init.luau
@@ -20,6 +20,10 @@ local function luau_error(message: string): Call<nil>
 	return projection.call(constant.from_value("error"), { constant.from_value(message) } :: any)
 end
 
+local function luau_assert(condition: RValue<boolean>, message: string): Call<nil>
+	return projection.call(constant.from_value("assert"), { condition, constant.from_value(message) :: any })
+end
+
 local function luau_typeof(of: RValue<any>): Call<string>
 	return projection.call(constant.from_value("typeof"), { of })
 end
@@ -30,6 +34,7 @@ end
 
 return table.freeze({
 	error = luau_error,
+	assert = luau_assert,
 	typeof = luau_typeof,
 	tostring = luau_tostring,
 

--- a/compiler/lir/build/builders/ty/init.luau
+++ b/compiler/lir/build/builders/ty/init.luau
@@ -369,9 +369,7 @@ builders = {
 
 			local out_of_bounds = condition.greater_than_or(stored_index, constant.from_value(total))
 
-			block:if_branch(out_of_bounds, function(block: fn.Builder)
-				block:call_lib(library.error(`Invalid enum variant`))
-			end)
+			block:call_lib(library.assert(out_of_bounds, "Invalid enum variant"))
 
 			for index, variant in enum.variants do
 				local is_variant = condition.equals(stored_index, constant.from_value(index - 1))

--- a/compiler/lir/build/builders/ty/luau/boolean.luau
+++ b/compiler/lir/build/builders/ty/luau/boolean.luau
@@ -30,9 +30,7 @@ local function validate(block: Builder, ty: Boolean, value: RValue<boolean>)
 	local type = constant.from_value("boolean")
 	local equals = condition.not_equals(value, type)
 
-	block:if_branch(equals, function(block)
-		block:call_lib(library.error(`Expected a boolean`))
-	end)
+	block:call_lib(library.assert(equals, "Expected a boolean"))
 end
 
 local function build_read(props: ReadProps, block: Builder, boolean: ty.Boolean, into: LValue<any>?): Register<boolean>

--- a/compiler/lir/build/builders/ty/luau/length.luau
+++ b/compiler/lir/build/builders/ty/luau/length.luau
@@ -95,9 +95,7 @@ local function validate_exact(block: Builder, ty: VariableLengthTy, value: RValu
 	local exact_length = to_exact_length(ty) :: number
 	local is_exact_length = condition.equals(value, constant.from_value(exact_length))
 
-	block:if_branch(is_exact_length, function(block)
-		block:call_lib(library.error(`Expected {ty.kind} length to be {bounds.min}`))
-	end)
+	block:call_lib(library.assert(is_exact_length, `Expected {ty.kind} length to be {bounds.min}`))
 end
 
 local function validate_range(block: Builder, ty: VariableLengthTy, len_register: LValue<number>)
@@ -109,13 +107,8 @@ local function validate_range(block: Builder, ty: VariableLengthTy, len_register
 	local lower = condition.less_than(len_register, constant.from_value(bounds.min))
 	local upper = condition.greater_than(len_register, constant.from_value(bounds.max))
 
-	block:if_branch(lower, function(block)
-		block:call_lib(library.error(`Expected {ty.kind} length to be greater than or equal to {bounds.min}`))
-	end)
-
-	block:if_branch(upper, function(block)
-		block:call_lib(library.error(`Expected {ty.kind} length to be less than or equal to {bounds.max}`))
-	end)
+	block:call_lib(library.assert(lower, `Expected {ty.kind} length to be greater than or equal to {bounds.min}`))
+	block:call_lib(library.assert(upper, `Expected {ty.kind} length to be less than or equal to {bounds.max}`))
 end
 
 local function read_length(

--- a/compiler/lir/build/builders/ty/luau/literal.luau
+++ b/compiler/lir/build/builders/ty/luau/literal.luau
@@ -26,11 +26,9 @@ type Register<T = any> = lir.RegisterId<T>
 
 local function validate(props: WriteProps, block: Builder, ty: Literal, value: RValue)
 	local constant = constant.from_ty(ty :: any)
-	local equals = condition.not_equals(value, constant :: any)
+	local equals = condition.equals(value, constant :: any)
 
-	block:if_branch(equals, function(block)
-		block:call_lib(library.error(`Expected "{ty.value}"`))
-	end)
+	block:call_lib(library.assert(equals, `Expected "{ty.value}"`))
 end
 
 local function build_read<A>(props: ReadProps, block: Builder, literal: ty.Literal, into: LValue<any>?): Register<A>

--- a/compiler/lir/build/builders/ty/luau/numeral.luau
+++ b/compiler/lir/build/builders/ty/luau/numeral.luau
@@ -162,16 +162,11 @@ local function validate(block: Builder, ty: ty.Numeral, value: RValue<number>)
 		return
 	end
 
-	local lower = condition.less_than(value, constant.from_value(bounds.min))
-	local upper = condition.greater_than(value, constant.from_value(bounds.max))
+	local lower = condition.less_than(value, constant.from_value(bounds.max))
+	local upper = condition.greater_than(value, constant.from_value(bounds.min))
 
-	block:if_branch(lower, function(block)
-		block:call_lib(library.error(`Expected number to be greater than or equal to {bounds.min}`))
-	end)
-
-	block:if_branch(upper, function(block)
-		block:call_lib(library.error(`Expected number to be less than or equal to {bounds.max}`))
-	end)
+	block:call_lib(library.assert(lower, `Expected number to be greater than or equal to {bounds.min}`))
+	block:call_lib(library.assert(upper, `Expected number to be less than or equal to {bounds.max}`))
 end
 
 local function build_read(props: ReadProps, block: Builder, ty: ty.Numeral, into: LValue<any>?): Register<number>

--- a/compiler/lir/build/builders/ty/luau/unit_enum.luau
+++ b/compiler/lir/build/builders/ty/luau/unit_enum.luau
@@ -35,11 +35,8 @@ local function build_read(props: ReadProps, block: Builder, enum: UnitEnum, into
 	local stored_index = numeral.read(props, block, format)
 	local value_register = (into or block:reserve()) :: Register<string>
 
-	local out_of_bounds = condition.greater_than_or(stored_index, constant.from_value(total))
-
-	block:if_branch(out_of_bounds, function(block)
-		block:call_lib(library.error(`Invalid enum variant`))
-	end)
+	local within_bounds = condition.less_than_or(stored_index, constant.from_value(total))
+	block:call_lib(library.assert(within_bounds, "Invalid enum variant"))
 
 	for index, variant in enum.variants do
 		local is_variant = condition.equals(stored_index, constant.from_value(index - 1))

--- a/compiler/lir/build/builders/ty/luau/vector.luau
+++ b/compiler/lir/build/builders/ty/luau/vector.luau
@@ -79,23 +79,20 @@ local function validate(block: Builder, vec: ty.Vector, value: RValue<vector>)
 	if bounds.min == bounds.max then
 		local exact_length = constant.from_value(bounds.min)
 		local is_exact_length = condition.equals(magnitude, exact_length)
-		block:if_branch(is_exact_length, function(block)
-			block:call_lib(library.error(`Expected vector length to be exactly {bounds.min}`))
-		end)
+
+		block:call_lib(library.assert(is_exact_length, `Expected vector length to be exactly {bounds.min}`))
 
 		return
 	end
 
-	local lower = condition.less_than(magnitude, constant.from_value(bounds.min))
-	local upper = condition.greater_than(magnitude, constant.from_value(bounds.max))
+	local lower = condition.less_than(magnitude, constant.from_value(bounds.max))
+	local upper = condition.greater_than(magnitude, constant.from_value(bounds.min))
 
-	block:if_branch(lower, function(block)
-		block:call_lib(library.error(`Expected vector length to be greater than or equal to {bounds.min}`))
-	end)
+	-- If lower is false, then it is above the max
+	block:call_lib(library.assert(lower, `Expected vector length to be greater than or equal to {bounds.min}`))
 
-	block:if_branch(upper, function(block)
-		block:call_lib(library.error(`Expected vector length to be less than or equal to {bounds.max}`))
-	end)
+	-- If upper is false, then it is below the minimum
+	block:call_lib(library.assert(upper, `Expected vector length to be less than or equal to {bounds.max}`))
 end
 
 local function build_read(props: ReadProps, block: Builder, vec: ty.Vector, into: LValue<any>?): Register<vector>

--- a/compiler/lir/build/builders/ty/roblox/enum.luau
+++ b/compiler/lir/build/builders/ty/roblox/enum.luau
@@ -50,11 +50,9 @@ local function validate(props: WriteProps, block: Builder, ty: ty.Enum, at: RVal
 	end
 
 	local enum_type = projection.index(at :: any, const("EnumType"))
-	local type_cond = condition.not_equals(enum_type, static_enum_type)
+	local is_type = condition.equals(enum_type, static_enum_type)
 
-	block:if_branch(type_cond, function(block)
-		block:call_lib(library.error(`Expected an enum of type: "{static_enum_type.value}"`))
-	end)
+	block:call_lib(library.assert(is_type, `Expected an enum of type: '{static_enum_type.value}'`))
 end
 
 local function build_read(props: ReadProps, block: Builder, ty: ty.Enum, into: LValue<any>?): Register<EnumItem>

--- a/compiler/lir/build/builders/ty/roblox/instance.luau
+++ b/compiler/lir/build/builders/ty/roblox/instance.luau
@@ -32,10 +32,8 @@ type Register<T> = lir.RegisterId<T>
 local DEFAULT_TYPE = constant.from_value("Instance")
 
 local function validate(ctx: Context, block: Builder, instance: Instance, value: RValue<Instance>)
-	local is_not_type = condition.not_equals(library.typeof(value :: any), DEFAULT_TYPE)
-	block:if_branch(is_not_type, function(block)
-		block:call_lib(library.error("Expected an Instance"))
-	end)
+	local is_type = condition.equals(library.typeof(value :: any), DEFAULT_TYPE)
+	block:call_lib(library.assert(is_type, "Expected an Instance"))
 
 	local class_ty_id = instance.class
 	if class_ty_id == nil then
@@ -48,9 +46,7 @@ local function validate(ctx: Context, block: Builder, instance: Instance, value:
 	local is_not_class =
 		condition.not_equals(library.Instance.is_a(value :: any, class_constant), constant.from_value(true))
 
-	block:if_branch(is_not_class, function(block)
-		block:call_lib(library.error(`Expected an Instance of class "{class_constant.value}"`))
-	end)
+	block:call_lib(library.assert(is_not_class, `Expected an Instance of class '{class_constant.value}'`))
 end
 
 local function validate_optional(ctx: Context, block: Builder, instance: Instance, value: RValue<Instance>)


### PR DESCRIPTION
This PR adds `assert` to the luau library and switches the if statements to be assertions.