### PR TITLE
Use table.clone instead of an empty table when reading structs

### DIFF
--- a/.lune/analyze.luau
+++ b/.lune/analyze.luau
@@ -20,5 +20,5 @@ for index, fflag in FFLAGS do
 end
 
 table.insert(options, "--ignore=vendor/**")
-table.insert(options, "./compiler/init.luau")
+table.insert(options, "./compiler")
 process.exec("luau-lsp", options, { stdio = "forward" })

--- a/compiler/codegen/init.luau
+++ b/compiler/codegen/init.luau
@@ -103,6 +103,8 @@ local function gen_id(ctx: Context, id: lir.Id<any>)
 		ctx.builder:append(`r{id.index}`)
 	elseif id.kind == "argument" then
 		ctx.builder:append(`a{id.index}`)
+	elseif id.kind == "upvalue" then
+		ctx.builder:append(`u_{id.index}`)
 	else
 		strong_exhaustive_match(id.kind)
 	end
@@ -417,6 +419,17 @@ function gen_block(ctx: Context, block: lir.BasicBlock)
 	gen_terminator(ctx, block.terminator)
 end
 
+local function gen_upvalue<T>(ctx: Context, upval: lir.UpvalueId<T>, default: lir.RValue<T>)
+	local name = upval.index
+
+	local builder = ctx.builder
+	builder:append("local ")
+	builder:append(`u_{name}`)
+	builder:append(" = ")
+	gen_rvalue(ctx, default)
+	builder:append("\n")
+end
+
 local function gen_fn(ctx: Context, fn: lir.Fn)
 	local builder = ctx.builder
 	table.clear(ctx.seen_registers)
@@ -455,6 +468,12 @@ local function from_lir(lirr: lir.Lir, target: compilation.Target): string
 	}
 
 	builder:append(BUFFER_TEMPLATE)
+
+	builder:append("-- upvalues start\n")
+	for upval_id, default in lirr.upvalues do
+		gen_upvalue(context, upval_id, default)
+	end
+	builder:append("-- upvalues end\n")
 
 	for _, fn in lirr.fns do
 		gen_fn(context, fn)

--- a/compiler/lir/build/builders/fn/init.luau
+++ b/compiler/lir/build/builders/fn/init.luau
@@ -72,6 +72,16 @@ local function register<T>(builder: Builder): Register<T>
 	}
 end
 
+local function upvalue<T>(index: string): lir.UpvalueId<T>
+	return {
+		__phantom_type = nil :: any,
+
+		type = "id",
+		kind = "upvalue",
+		index = index,
+	}
+end
+
 local function store<T, R>(self: Builder, value: RValue<T>, into: LValue<R>?): Register<T>
 	local register = (into or register(self))
 	local assign = statement.assign(register, value)
@@ -200,6 +210,17 @@ local function call_fn(self: Builder, fn_id: FnId, args: { RValue }, rets: { LVa
 	table.insert(self.blocks, next_block)
 end
 
+local function add_upvalue<T>(self: Builder, upvalue_name: string, upvalue_default: RValue<T>)
+	local upval = upvalue(upvalue_name)
+	self.ctx.lir.upvalues[upval] = upvalue_default
+
+	return upval
+end
+
+local function ref_upvalue(self: Builder, name: string): lir.UpvalueId<any>
+	return upvalue(name)
+end
+
 export type Builder = {
 	ctx: Context,
 	block: BasicBlock,
@@ -223,6 +244,9 @@ export type Builder = {
 
 	for_numeric: typeof(for_numeric),
 	for_generic: typeof(for_generic),
+
+	add_upvalue: typeof(add_upvalue),
+	ref_upvalue: typeof(ref_upvalue),
 
 	argument: (self: Builder, index: number) -> lir.ArgumentId<any>,
 }
@@ -270,6 +294,9 @@ local function create(ctx: Context, name: string, args: { Argument }, rets: { Re
 		for_numeric = for_numeric,
 		for_generic = for_generic,
 
+		add_upvalue = add_upvalue,
+		ref_upvalue = ref_upvalue,
+
 		argument = argument_id,
 	}
 
@@ -291,4 +318,5 @@ return table.freeze({
 	create = create,
 	rreturn = rreturn,
 	argument = argument,
+	upvalue = upvalue,
 })

--- a/compiler/lir/build/builders/library/table.luau
+++ b/compiler/lir/build/builders/library/table.luau
@@ -16,7 +16,12 @@ local function insert<T>(into: RValue<{ T }>, value: RValue<T>)
 	return projection.call(constant.from_value("table.insert"), { into, value })
 end
 
+local function clone<T>(template: RValue<T>)
+	return projection.call(constant.from_value("table.clone"), { template })
+end
+
 return table.freeze({
+	clone = clone,
 	create = create,
 	insert = insert,
 })

--- a/compiler/lir/build/builders/ty/init.luau
+++ b/compiler/lir/build/builders/ty/init.luau
@@ -165,6 +165,8 @@ local function from_ty_id(ctx: Context, attributes: attributes.Attributes, ty_id
 			ctx = ctx,
 			generics = generics,
 			attributes = attributes,
+
+			ty_id = ty_id,
 		}
 
 		local value_register = read_ty(props, block, ty)
@@ -304,12 +306,13 @@ builders = {
 
 	struct = table.freeze({
 		read = function(props: ReadProps, block: Builder, struct: ty.Struct, into: LValue<any>?): Register<any>
-			local register: Register<any> = block:store(structure.struct({}))
+			local register: Register<any> = block:store(library.table.clone(block:ref_upvalue(tostring(props.ty_id))))
+
 			for _, field in struct.fields do
-				local name = field.name
+				local field_name = field.name
 				local value_register = read_ty_id(props, block, field.value)
 
-				local struct_index = projection.field(register, constant.from_value(name))
+				local struct_index = projection.field(register, constant.from_value(field_name))
 				block:store(value_register, struct_index)
 			end
 

--- a/compiler/lir/build/builders/ty/types.luau
+++ b/compiler/lir/build/builders/ty/types.luau
@@ -21,6 +21,8 @@ export type ReadProps = {
 	-- This is an ugly hack for instances
 	is_optional: boolean?,
 	attributes: Attributes,
+
+	ty_id: TyId,
 }
 
 export type WriteProps = {

--- a/compiler/lir/build/init.luau
+++ b/compiler/lir/build/init.luau
@@ -14,6 +14,9 @@ local builders = require("@builders/init")
 local context = require("@self/context")
 local types = require("@builders/ty/types")
 
+local constant = require("@builders/constant")
+local structure = require("@builders/structure")
+
 local panic = require("@util/panic")
 local strong_exhaustive_match = require("@util/strong_exhaustive_match")
 
@@ -53,6 +56,16 @@ local function options_from_decl_id(ctx: Context, decl_id: DeclId): options.File
 	return options
 end
 
+local function create_struct_template<T>(ty_id: TyId, struct: ty.Struct)
+	local fields = {}
+
+	for _, field in struct.fields do
+		fields[constant.from_value(field.name)] = constant.null
+	end
+
+	return structure.struct(fields :: any)
+end
+
 local function rreturns(ctx: Context, parameters: { hir.Parameter }): { lir.Return }
 	local array = {}
 	for index, parameter in parameters do
@@ -75,6 +88,14 @@ local function build_type(ctx: Context, decl_id: DeclId): lir.Type
 	local decl = hir.decl_from_id(ctx.hir, decl_id)
 	if decl.generics then
 		return nil :: any
+	end
+
+	local ty = hir.ty_from_id(ctx.hir, decl.ty_id)
+
+	if ty.kind == "struct" then
+		local template = create_struct_template(decl.ty_id, ty)
+
+		ctx.lir.upvalues[builders.fn.upvalue(tostring(decl.ty_id))] = template
 	end
 
 	return {
@@ -101,6 +122,7 @@ local function from_hir(hir: hir.Hir): lir.Lir
 		types = {},
 		events = {},
 		functions = {},
+		upvalues = {},
 	}
 
 	local ctx: Context = context.create(hir, lir)

--- a/compiler/lir/format.luau
+++ b/compiler/lir/format.luau
@@ -47,6 +47,8 @@ local function fmt_id(fmt_builder: StringBuilder, id: lir.Id<any>)
 		string_builder.append(fmt_builder, ID_STYLE("a"))
 	elseif id.kind == "register" then
 		string_builder.append(fmt_builder, ID_STYLE("$"))
+	elseif id.kind == "upvalue" then
+		string_builder.append(fmt_builder, ID_STYLE("u_"))
 	else
 		strong_exhaustive_match(id.kind)
 	end

--- a/compiler/lir/types.luau
+++ b/compiler/lir/types.luau
@@ -50,10 +50,20 @@ export type RegisterId<T> = {
 	index: number,
 }
 
+--- Index into the upvalue table
+export type UpvalueId<T> = {
+	write __phantom_type: T,
+
+	type: "id",
+	kind: "upvalue",
+	index: string,
+}
+
 --stylua: ignore
-export type Id<T> = 
+export type Id<T> =
     | ArgumentId<T>
     | RegisterId<T>
+    | UpvalueId<T>
 
 --- base(args...)
 export type ProjCall<T> = {
@@ -94,6 +104,15 @@ export type ProjNamecall<T> = {
 	base: LValue<T> | Constant<T>,
 	method: Constant<T>,
 	args: { RValue<T> },
+}
+
+export type ProjShapedTable<T> = {
+	write __phantom_type: T,
+
+	type: "projection",
+	kind: "shaped_table",
+	base: LValue<T>,
+	shape: { string },
 }
 
 --stylua: ignore
@@ -276,12 +295,14 @@ export type LValue<T> =
     | ProjIndex<T>
     | RegisterId<T>
     | ArgumentId<T>
+    | UpvalueId<T>
 
 --- right side of an assign statement
 --stylua: ignore
 export type RValue<T> =
 	| RegisterId<T>
 	| ArgumentId<T>
+	| UpvalueId<T>
 	| Structure<T>
 	| Global<T>
 	| Control<T>
@@ -454,6 +475,9 @@ export type Lir = {
 	types: { [hir.DeclId]: Type },
 	events: { [hir.DeclId]: Event },
 	functions: { [hir.DeclId]: Function },
+
+	-- mutable upvalues
+	upvalues: { [UpvalueId<any>]: RValue<any> },
 }
 
 local function fn_from_id(lir: Lir, fn_id: FnId): Fn


### PR DESCRIPTION
This PR implements an optimization where a shaped table is cloned, instead of an empty completely dynamic table.

This also required the implementation of upvalues into codegen & LIR