### PR TITLE
Fix incorrect usage of Unit Enums in Docs

### DIFF
--- a/docs/pages/language/4-types.mdx
+++ b/docs/pages/language/4-types.mdx
@@ -233,7 +233,7 @@ Units enums represent a set of possible values.<br/>
 They are defined using the `enum` type. 
 For example, a unit enum representing the state of a character:
 ```blink copy
-type CharacterStatus = enum { Idling, Walking, Running, Jumping, Falling }
+enum CharacterStatus = { Idling, Walking, Running, Jumping, Falling }
 ```
 
 ### Tagged Enums


### PR DESCRIPTION
Incorrect usage of Unit Enums:
`type CharacterStatus = enum { Idling, Walking, Running, Jumping, Falling }`
Correct Usage
`enum CharacterStatus = { Idling, Walking, Running, Jumping, Falling }`