### PR TITLE
Support absolute paths in imports

### DIFF
--- a/src/Modules/Path.luau
+++ b/src/Modules/Path.luau
@@ -14,8 +14,22 @@ local Utility = {}
 
 ---- Public Functions ----
 
+function Utility.PathType(Path: string): "absolute" | "relative"
+	-- on unix-based systems, '/' is root
+	if string.sub(Path, 1, 1) == "/" then
+		return "absolute"
+	end
+
+	-- on windows systems, it is %w:[\\/]
+	if string.sub(Path, 2, 2) == ":" then
+		return "absolute"
+	end
+
+	return "relative"
+end
+
 function Utility.Components(Path: string): (string?, string?, string?)
-	local Filename: string?;
+	local Filename: string?
 	local Directory, FilenameExt, Extension = string.match(Path, "(.-)([^\\/]-%.?([^%.\\/]*))$")
 
 	if FilenameExt then
@@ -32,17 +46,17 @@ end
 
 function Utility.Filename(Path: string): string?
 	local _, Filename = Utility.Components(Path)
-    return Filename
+	return Filename
 end
 
 function Utility.Directory(Path: string): string?
 	local Directory = Utility.Components(Path)
-    return Directory
+	return Directory
 end
 
 function Utility.Extension(Path: string): string?
 	local _, _, Extension = Utility.Components(Path)
-    return Extension
+	return Extension
 end
 
 function Utility.NameWithExtension(Path: string): string?

--- a/src/Parser.luau
+++ b/src/Parser.luau
@@ -354,7 +354,9 @@ local function GetFileSource(Path: string, Directory: string): (string?, string?
     local fs = require("@lune/fs")
     local GetDefinitionFilePath = require("./CLI/Utility/GetDefinitionFilePath.luau")
 
-    Path = `{Directory}{Path}`
+    if PathParser.PathType(Path) == "relative" then
+         Path = `{Directory}{Path}`
+    end
     Path = GetDefinitionFilePath(Path)
 
     if not fs.isFile(Path) then
@@ -852,9 +854,9 @@ function Parser.Import(self: Parser): ScopeNode
         local Indices = string.split(ImportPath, ".")
         Name = Indices[#Indices]
     else
-        if string.sub(ImportPath, 1, 2) ~= "./" then
-            ImportPath = `./{ImportPath}`
-        end
+          if PathParser.PathType(ImportPath) == "absolute" and string.sub(ImportPath, 1, 2) ~= "./" then
+               ImportPath = `./{ImportPath}`
+          end
 
         --> Use file name as namespace identifier
         local Filename = PathParser.Filename(ImportPath)


### PR DESCRIPTION
This PR adds absolute path support to imports, by including checks for absolute paths (starting with `%w:` or `/`) when handling relative paths.

This PR also introduces a function into `Utility` labelled `PathType`, which returns if the path is absolute or relative