### PR TITLE
Add syncing for toolbar button state with widget enabled state

### DIFF
--- a/plugin/src/init.server.luau
+++ b/plugin/src/init.server.luau
@@ -400,6 +400,10 @@ local function OnEditorButtonClicked()
     EditorWidget.Enabled = not EditorWidget.Enabled
 end
 
+local function OnEditorWidgetEnabled()
+	EditorButton:SetActive(EditorWidget.Enabled)
+end
+
 local function OnQuickSave()
     if Expanded:Get() then
         return
@@ -507,3 +511,4 @@ Expand.MouseButton2Click:Connect(OnExpandRightClicked)
 QuickSave.MouseButton1Click:Connect(OnQuickSave)
 QuickClear.MouseButton1Click:Connect(OnQuickClear)
 EditorButton.Click:Connect(OnEditorButtonClicked)
+EditorWidget:GetPropertyChangedSignal("Enabled"):Connect(OnEditorWidgetEnabled)


### PR DESCRIPTION
When the configuration editor widget is closed via the X button, the toolbar button remains visually active (desaturated) instead of returning to normal. This PR syncs the toolbar button state with the widget's enabled state to correctly reflect the widget's open/closed state.